### PR TITLE
Bugfix accel calculation on XS units

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -467,7 +467,7 @@ function calcRanking() {
             dcv.combo_speed_rate = getComboSpeedRate(dcv.sv.c.combo_speed, boss.combo);
             dcv.acceleration_rate = 1.0;
             dcv.acceleration_offset = 0.0;
-            if (dcv.sv.c.rarity === 6) {
+            if (dcv.sv.c.rarity >= 6) {
                 if (boss.ingame) {
                     dcv.acceleration_rate = 3.0;
                 } else {


### PR DESCRIPTION
After cc413b79d56f21da42492d660ab04d07ff78f24d, internally stored value for rarity changed from 6 to 6.5 for XS units